### PR TITLE
Fix bugs in views, and comment encryption

### DIFF
--- a/app/controllers/reputation_web_service_controller.rb
+++ b/app/controllers/reputation_web_service_controller.rb
@@ -187,10 +187,10 @@ class ReputationWebServiceController < ApplicationController
   # Unoformatted string data is converted into JSON format in this method.
   # JSON formatted request body is returned to the prepare_request_body method.
   def format_into_json(unformatted_data)
-    unformatted_data.prepend('{"keys":"')
-    unformatted_data << '"}'
+    unformatted_data.prepend('{"keys":')
+    unformatted_data << '}'
     formatted_data = unformatted_data.gsub!(/\n/, '\\n')
-
+    formatted_data = formatted_data.nil? ? unformatted_data : formatted_data
     formatted_data
   end
 
@@ -293,7 +293,7 @@ class ReputationWebServiceController < ApplicationController
   # It further calls the methods: encrypt_request_body and format_into_json to get the request body into the correct format.
   # It finally sends the prepared request body back to the send_post_request method.
   def prepare_request_body
-    req = Net::HTTP::Post.new('/reputation/calculations/reputation_algorithms', initheader: { 'Content-Type' => 'application/json', 'charset' => 'utf-8' })
+    req = Net::HTTP::Post.new('/reputation/calculations/reputation_algorithms', { 'Content-Type' => 'application/json', 'charset' => 'utf-8' })
     curr_assignment_id = (params[:assignment_id].empty? ? '754' : params[:assignment_id])
     assignment_id_list_peers = get_assignment_id_list(curr_assignment_id, params[:another_assignment_id].to_i)
     req.body = generate_json_for_peer_reviews(assignment_id_list_peers, params[:round_num].to_i).to_json

--- a/app/controllers/reputation_web_service_controller.rb
+++ b/app/controllers/reputation_web_service_controller.rb
@@ -231,7 +231,7 @@ class ReputationWebServiceController < ApplicationController
   def process_response_body(response)
     # Decryption
 
-    response.body = decrypt_response(response.body)
+    # response.body = decrypt_response(response.body)
 
     @response = response
     @response_body = response.body
@@ -319,10 +319,10 @@ class ReputationWebServiceController < ApplicationController
     req.body.prepend('{')
     @request_body = req.body
     # Encrypting the request body data
-    req.body = encrypt_request_body(req.body)
+    # req.body = encrypt_request_body(req.body)
 
     # request body should be in JSON format.
-    req.body = format_into_json(req.body)
+    # req.body = format_into_json(req.body)
     req
   end
 

--- a/app/controllers/reputation_web_service_controller.rb
+++ b/app/controllers/reputation_web_service_controller.rb
@@ -160,7 +160,9 @@ class ReputationWebServiceController < ApplicationController
 
   # This method returns the id of the last assignment.
   def client
-    @max_assignment_id = Assignment.last.id
+    flash[:max_assignment_id] = Assignment.last.id
+    flash[:assignment] = Assignment.find(flash[:assignment_id]) rescue nil
+    flash[:another_assignment] = Assignment.find(flash[:another_assignment_id]) rescue nil
   end
 
   # encrypt_request_body is used by the method prepare_request_body.
@@ -231,11 +233,10 @@ class ReputationWebServiceController < ApplicationController
 
   def process_response_body(response)
     # Decryption
-
     # response.body = decrypt_response(response.body)
 
-    @response = response
-    @response_body = response.body
+    flash[:response] = response
+    flash[:response_body] = response.body
 
     update_participants_reputation(response)
   end
@@ -244,7 +245,7 @@ class ReputationWebServiceController < ApplicationController
   # It prepends the request body with the expert grades pertaining to the default wiki contribution case of 754
   # It receives the request body as an argument, prepends it, and returns the body to the caller function (prepare_request_body)
   def add_expert_grades(body)
-    @additional_info = 'add expert grades'
+    flash[:additional_info] = 'add expert grades'
     case params[:assignment_id]
     when '754' # expert grades of Wiki contribution (754)
       body.prepend('"expert_grades": {"submission25030":95,"submission25031":92,"submission25033":88,"submission25034":98,"submission25035":100,"submission25037":95,"submission25038":95,"submission25039":93,"submission25040":96,"submission25041":90,"submission25042":100,"submission25046":95,"submission25049":90,"submission25050":88,"submission25053":91,"submission25054":96,"submission25055":94,"submission25059":96,"submission25071":85,"submission25082":100,"submission25086":95,"submission25097":90,"submission25098":85,"submission25102":97,"submission25103":94,"submission25105":98,"submission25114":95,"submission25115":94},')
@@ -256,7 +257,7 @@ class ReputationWebServiceController < ApplicationController
   # It gets the assignment id list and generates the json on quiz scores of those assignments.
   # Finally processes quiz string is prepended to the request body, received as an argument, and returns the body to prepare_request_body.
   def add_quiz_scores(body)
-    @additional_info = 'add quiz scores'
+    flash[:additional_info] = 'add quiz scores'
     assignment_id_list_quiz = get_assignment_id_list(params[:assignment_id].to_i, params[:another_assignment_id].to_i)
     quiz_str =  generate_json_for_quiz_scores(assignment_id_list_quiz).to_json
     quiz_str[0] = ''
@@ -269,13 +270,13 @@ class ReputationWebServiceController < ApplicationController
   # add_hamer_reputation_values sets the instance variable @additional_info.
   # This method is called by the prepare_request_body method when params receive instruction through the corresponding view's checkbox.
   def add_hamer_reputation_values
-    @additional_info = 'add initial hamer reputation values'
+    flash[:additional_info] = 'add initial hamer reputation values'
   end
 
   # add_lauw_reputation_values sets the instance variable @additional_info.
   # This method is called by the prepare_request_body method when params receive instruction through the corresponding view's checkbox.
   def add_lauw_reputation_values
-    @additional_info = 'add initial lauw reputation values'
+    flash[:additional_info] = 'add initial lauw reputation values'
   end
 
   # get_assignment_id_list on receipt of individual assignment IDs returns a list with all the assignment IDs appended into a data structure
@@ -296,13 +297,14 @@ class ReputationWebServiceController < ApplicationController
     req = Net::HTTP::Post.new('/reputation/calculations/reputation_algorithms', { 'Content-Type' => 'application/json', 'charset' => 'utf-8' })
     curr_assignment_id = (params[:assignment_id].empty? ? '754' : params[:assignment_id])
     assignment_id_list_peers = get_assignment_id_list(curr_assignment_id, params[:another_assignment_id].to_i)
+
     req.body = generate_json_for_peer_reviews(assignment_id_list_peers, params[:round_num].to_i).to_json
 
     req.body[0] = '' # remove the first '{'
-    @assignment_id = params[:assignment_id]
-    @round_num = params[:round_num]
-    @algorithm = params[:algorithm]
-    @another_assignment_id = params[:another_assignment_id]
+    flash[:assignment_id] = params[:assignment_id]
+    flash[:round_num] = params[:round_num]
+    flash[:algorithm] = params[:algorithm]
+    flash[:another_assignment_id] = params[:another_assignment_id]
 
     if params[:checkbox][:expert_grade] == 'Add expert grades'
       add_expert_grades(req.body)
@@ -313,11 +315,11 @@ class ReputationWebServiceController < ApplicationController
     elsif params[:checkbox][:quiz] == 'Add quiz scores'
       add_quiz_scores(req.body)
     else
-      @additional_info = ''
+      flash[:additional_info] = ''
     end
 
     req.body.prepend('{')
-    @request_body = req.body
+    flash[:request_body] = req.body
     # Encrypting the request body data
     # req.body = encrypt_request_body(req.body)
 
@@ -333,7 +335,7 @@ class ReputationWebServiceController < ApplicationController
   def send_post_request
     req = prepare_request_body
     response = Net::HTTP.new('peerlogic.csc.ncsu.edu').start { |http| http.request(req) }
-    if  %w[400 500].include?(response.code)
+    if %w[400 500].include?(response.code)
       flash[:error] = 'Post Request Failed'
     else
       process_response_body(response)

--- a/app/views/reputation_web_service/client.html.erb
+++ b/app/views/reputation_web_service/client.html.erb
@@ -49,9 +49,9 @@
 <!--Request information-->
 <%= "Request info: #{flash[:assignment].name} (#{flash[:assignment].id})" unless flash[:assignment].nil? %>
 <%= " + #{flash[:another_assignment].name} (#{flash[:another_assignment].id})" unless flash[:another_assignment].nil? %>
-<%= "<br/>round #{flash[:round_num]}" unless flash[:assignment].nil? %>
-<%= "<br/>#{flash[:algorithm]} algorithm" unless flash[:assignment].nil? %>
-<%= "<br/>#{flash[:additional_info]}" unless flash[:additional_info].try(:empty?) %>
+<%= " + round #{flash[:round_num]}" unless flash[:assignment].nil? %>
+<%= " + #{flash[:algorithm]} algorithm" unless flash[:assignment].nil? %>
+<%= " + #{flash[:additional_info]}" unless flash[:additional_info].try(:empty?) %>
 <br/><br/>
 
 <!--Beautified request and response message-->

--- a/app/views/reputation_web_service/client.html.erb
+++ b/app/views/reputation_web_service/client.html.erb
@@ -1,5 +1,8 @@
 <%= form_tag action: "send_post_request" do %>
-	<b style="font-size: 20px;">Step 1: </b>Assignment_id: <%= number_field_tag 'assignment_id', nil, in: 1..@max_assignment_id, value: @assignment.nil? ? 754 : @assignment.id, style: 'width: 3em;' %> + <%= number_field_tag 'another_assignment_id', nil, in: 1..@max_assignment_id, value: @another_assignment.nil? ? '' : @another_assignment.id, style: 'width: 3em;' %> (optional) with round <%= number_field_tag 'round_num', nil, in: 1..3, value: 2, style: 'width: 2em;' %><br>
+	<b style="font-size: 20px;">Step 1: </b>
+	Assignment_id: <%= number_field_tag 'assignment_id', nil, in: 1..flash[:max_assignment_id], value: flash[:assignment].nil? ? 754 : flash[:assignment].id, style: 'width: 3em;' %> + 
+	<%= number_field_tag 'another_assignment_id', nil, in: 1..flash[:max_assignment_id], value: flash[:another_assignment].nil? ? '' : flash[:another_assignment].id, style: 'width: 3em;' %> 
+	(optional) with round <%= number_field_tag 'round_num', nil, in: 1..3, value: 2, style: 'width: 2em;' %><br>
 
 	<b style="font-size: 20px;">Step 2: </b>Choose reputation algorithm:
 	<select id='algorithm' name='algorithm' style="width: 13em">
@@ -32,11 +35,11 @@
 	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 	<%= hidden_field_tag 'checkbox[hamer]', '' %>
 	<%= check_box_tag 'checkbox[hamer]', 'Add initial Hamer reputation values' %>Add initial Hamer reputation values 
-	with assignment_id: <%= number_field_tag 'hamer_assignment_id', nil, in: 1..@max_assignment_id, value: '', style: 'width: 3em;' %> + <%= number_field_tag 'another_hamer_assignment_id', nil, in: 1..@max_assignment_id, value: '', style: 'width: 3em;' %> (optional) <br/>
+	with assignment_id: <%= number_field_tag 'hamer_assignment_id', nil, in: 1..flash[:max_assignment_id], value: '', style: 'width: 3em;' %> + <%= number_field_tag 'another_hamer_assignment_id', nil, in: 1..flash[:max_assignment_id], value: '', style: 'width: 3em;' %> (optional) <br/>
 	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 	<%= hidden_field_tag 'checkbox[lauw]', '' %> 
 	<%= check_box_tag 'checkbox[lauw]', 'Add initial Lauw reputation values' %>Add initial Lauw reputation values 
-	with assignment_id:&nbsp;&nbsp;&nbsp;<%= number_field_tag 'lauw_assignment_id', nil, in: 1..@max_assignment_id, value: '', style: 'width: 3em;' %> + <%= number_field_tag 'another_lauw_assignment_id', nil, in: 1..@max_assignment_id, value: '', style: 'width: 3em;' %> (optional) <br/>
+	with assignment_id:&nbsp;&nbsp;&nbsp;<%= number_field_tag 'lauw_assignment_id', nil, in: 1..flash[:max_assignment_id], value: '', style: 'width: 3em;' %> + <%= number_field_tag 'another_lauw_assignment_id', nil, in: 1..flash[:max_assignment_id], value: '', style: 'width: 3em;' %> (optional) <br/>
 	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 	<%= hidden_field_tag 'checkbox[quiz]', '' %>
 	<%= check_box_tag 'checkbox[quiz]', 'Add quiz scores' %>Add quiz scores <br/>
@@ -44,11 +47,11 @@
 <% end %>
 <hr>
 <!--Request information-->
-<%= "Request info: #{@assignment.name} (#{@assignment.id})" unless @assignment.nil? %>
-<%= " + #{@another_assignment.name} (#{@another_assignment.id})" unless @another_assignment.nil? %>
-<%= " + round #{@round_num}" unless @assignment.nil? %>
-<%= " + #{@algorithm} algorithm" unless @assignment.nil? %>
-<%= " + #{@additional_info}" unless @additional_info.try(:empty?) %>
+<%= "Request info: #{flash[:assignment].name} (#{flash[:assignment].id})" unless flash[:assignment].nil? %>
+<%= " + #{flash[:another_assignment].name} (#{flash[:another_assignment].id})" unless flash[:another_assignment].nil? %>
+<%= "<br/>round #{flash[:round_num]}" unless flash[:assignment].nil? %>
+<%= "<br/>#{flash[:algorithm]} algorithm" unless flash[:assignment].nil? %>
+<%= "<br/>#{flash[:additional_info]}" unless flash[:additional_info].try(:empty?) %>
 <br/><br/>
 
 <!--Beautified request and response message-->
@@ -68,9 +71,9 @@
 <!--Minified request and response message-->
 <b>Minified request and response message</b><br/>
 <p style="background-color: #fdf6e3; color: #657b83; padding: 5px; word-wrap: break-word;">
-	<%=@request_body unless @request_body.try(:empty?) %><br/><br/>
-	<%="Response #{@response.try(:code)} #{@response.try(:message)}:
-          #{@response.try(:body)}" unless @response == '' %>
+	<%=flash[:request_body] unless flash[:request_body].try(:empty?) %><br/><br/>
+	<%="Response #{flash[:response].try(:code)} #{flash[:response].try(:message)}:
+          #{flash[:response].try(:body)}" unless flash[:response] == '' %>
 </p>
 
 
@@ -121,8 +124,8 @@
 		// http://stackoverflow.com/questions/5410682/parsing-a-json-string-in-ruby
 		// http://stackoverflow.com/questions/9244824/how-to-remove-quot-from-my-json-in-javascript
 		// &quot; is not valid in a JSON object, and g in replace means replace globally
-		var request = JSON.parse('<%= @request_body %>'.replace(/&quot;/g,'"'));
-		var response = JSON.parse('<%= @response_body %>'.replace(/&quot;/g,'"'));
+		var request = JSON.parse('<%= flash[:request_body] %>'.replace(/&quot;/g,'"'));
+		var response = JSON.parse('<%= flash[:response_body] %>'.replace(/&quot;/g,'"'));
 		
 		$('#request').html(library.json.prettyPrint(request));
 		$('#response').html(library.json.prettyPrint(response));


### PR DESCRIPTION
Changes in this pull request:
1. Comment of encryption and decryption if request post body as it is no more in use
2. whenever a post request fails to the reputation webservice it fails disgracefully, handling the cases when it fails
3. JSON is badly formatted and cannot be deserialized correctly
4. change the instance variables used to flash as after the post request is successful, it must be returned to the client page with the response, in a formatted manner.
5. fix incorrect usage of gsub!

fixes #14 #13 